### PR TITLE
fix #4 - text overlap between content and right nav

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -92,3 +92,9 @@ $link-hover-color: $secondary;
 pre, code {
   background-color: #f6f8fa;
 }
+
+.docs-content {
+    overflow: auto;
+    scrollbar-width: thin;
+    scrollbar-color: $gray-200 $white;
+}


### PR DESCRIPTION
This PR sets the central content pane to use an horizontal scrollbar.