### PR TITLE
synchronize.sh: switch from git:// to https://

### DIFF
--- a/synchronize.sh
+++ b/synchronize.sh
@@ -5,8 +5,8 @@ set -xe
 rm -rf repos/
 mkdir repos/
 
-git clone git://github.com/prometheus-operator/prometheus-operator -b main --depth 1 repos/prometheus-operator
-git clone git://github.com/prometheus-operator/kube-prometheus -b main --depth 1 repos/kube-prometheus
+git clone https://github.com/prometheus-operator/prometheus-operator -b main --depth 1 repos/prometheus-operator
+git clone https://github.com/prometheus-operator/kube-prometheus -b main --depth 1 repos/kube-prometheus
 
 # prometheus-operator
 


### PR DESCRIPTION
GitHub removed support for the unauthenticate Git protocol (see
https://github.blog/2021-09-01-improving-git-protocol-security-github/).
