### PR TITLE
Bring back theme overrides

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -4,6 +4,15 @@
 /** Import theme variables */
 @import "common/variables";
 
+$kubernetes: #3371e3;
+$prometheus: #e6522c;
+
+$primary: $kubernetes;
+$secondary: $prometheus;
+
+$link-color: $primary;
+$link-hover-color: $secondary;
+
 /** Import Bootstrap */
 @import "bootstrap/scss/bootstrap";
 
@@ -33,3 +42,70 @@
 @import "layouts/pages";
 @import "layouts/posts";
 @import "layouts/sidebar";
+
+
+
+::selection {
+  background: lighten($primary, 25%);
+}
+
+[data-dark-mode] ::selection {
+  background: darken($primary, 25%);
+}
+
+:root {
+  --kubernetes: #3371e3;
+  --prometheus: #e6522c;
+}
+
+.header-bar {
+  border-top: none;
+  height: 4px;
+  background: linear-gradient(90deg, var(--kubernetes), var(--prometheus), var(--kubernetes));
+  background-size: 200% 200%;
+
+  -webkit-animation: headerBarGradient 15s ease infinite;
+  -moz-animation: headerBarGradient 15s ease infinite;
+  animation: headerBarGradient 15s ease infinite;
+}
+
+@-webkit-keyframes headerBarGradient {
+  0%{background-position:0% 0%}
+  50%{background-position:200% 0%}
+  100%{background-position:400% 0%}
+}
+@-moz-keyframes headerBarGradient {
+  0%{background-position:0% 0%}
+  50%{background-position:200% 0%}
+  100%{background-position:400% 0%}
+}
+@keyframes headerBarGradient {
+  0%{background-position:0% 0%}
+  50%{background-position:200% 0%}
+  100%{background-position:400% 0%}
+}
+
+.navbar-light .navbar-nav .nav-link:hover {
+  color: var(--prometheus);
+}
+
+.home .btn-primary:hover {
+  background-color: var(--prometheus);
+  border-color: var(--prometheus);
+}
+
+.docs-link:hover,
+.docs-link.active,
+.page-links a:hover {
+  color: var(--prometheus);
+}
+
+pre, code {
+  background-color: #f6f8fa;
+}
+
+.docs-content {
+    overflow: auto;
+    scrollbar-width: thin;
+    scrollbar-color: $gray-200 $white;
+}


### PR DESCRIPTION
We can set a dark-mode selection color to fix the highlighting.
Everything else stayed the same for the dark mode.

This snippet sets a more readable highlight color in dark mode.
```
[data-dark-mode] ::selection {
  background: darken($primary, 25%);
}
```
In light mode it's 25% lighter than the primary color (blue) and in dark mode it's 25% darker. Looked pretty good locally.

---

![light](https://user-images.githubusercontent.com/872251/178991300-b7ecf34d-f018-4482-b558-98069a45f1d5.png)
---
![dark](https://user-images.githubusercontent.com/872251/178991307-c4f2c5de-6ec0-40ba-8d7e-d7370be74ae6.png)

