### PR TITLE
Fix broken links in contributing page

### DIFF
--- a/synchronize.sh
+++ b/synchronize.sh
@@ -23,6 +23,12 @@ cp -r repos/prometheus-operator/Documentation/img static/img
 
 # prologue section
 cp repos/prometheus-operator/CONTRIBUTING.md content/docs/prologue/contributing.md
+# copy linked pages
+cp repos/prometheus-operator/LICENSE content/docs/prologue/license.md
+cp repos/prometheus-operator/code-of-conduct.md content/docs/prologue/code-of-conduct.md
+cp repos/prometheus-operator/DCO content/docs/prologue/dco.md
+cp repos/prometheus-operator/README.md content/docs/prologue/README.md
+cp repos/prometheus-operator/TESTING.md content/docs/prologue/TESTING.md
 
 # user guides section
 cp repos/prometheus-operator/Documentation/user-guides/getting-started.md content/docs/user-guides/getting-started.md


### PR DESCRIPTION
All of the relative links in the [contributing](https://prometheus-operator.dev/docs/prologue/contributing/) page are broken, I see the relative linked docs are not copied from the repo.

Following are the broken links

- [x] https://prometheus-operator.dev/docs/prologue/contributing/LICENSE
- [x] https://prometheus-operator.dev/docs/prologue/contributing/code-of-conduct.md
- [x] https://prometheus-operator.dev/docs/prologue/contributing/DCO
- [x] https://prometheus-operator.dev/docs/prologue/contributing/README.md
- [x] https://prometheus-operator.dev/docs/prologue/contributing/TESTING.md
- [ ] https://prometheus-operator.dev/docs/prologue/contributing/scripts/run-external.sh

Fixing `scripts/run-external.sh` is tricky, to render it properly with Hugo I need to add a layout shortcode to wrap the script within a code block. 