### PR TITLE
Added cards for different guides in Introduction page

### DIFF
--- a/content/docs/getting-started/introduction.md
+++ b/content/docs/getting-started/introduction.md
@@ -40,14 +40,14 @@ The Prometheus operator includes, but is not limited to, the following features:
 {{<link-card
   title="Developer Guide"
   href="https://prometheus-operator.dev/docs/developer/getting-started/"
-  description="Learn how to configure monitoring for your applications."
+  description="Learn how to configure scraping, alerting, and recording rules for your applications."
 >}}
 
 <!-- Platform Guide -->
 {{<link-card
   title="Platform Guide"
   href="https://prometheus-operator.dev/docs/platform/webhook/"
-  description="Set up, configure and manage instances of Prometheus and related resources."
+  description="Set up, configure and manage instances of Prometheus-Operator, Prometheus, Alertmanager and ThanosRuler resources."
 >}}
 
 <!-- Community -->

--- a/content/docs/getting-started/introduction.md
+++ b/content/docs/getting-started/introduction.md
@@ -22,32 +22,37 @@ The Prometheus operator includes, but is not limited to, the following features:
 - Simplified Deployment Configuration: Configure the fundamentals of Prometheus like versions, persistence, retention policies, and replicas from a native Kubernetes resource.
 - Prometheus Target Configuration: Automatically generate monitoring target configurations based on familiar Kubernetes label queries; no need to learn a Prometheus specific configuration language.
 
-## Get started
+<!-- Getting-Started -->
+{{<link-card
+  title="Getting-Started"
+  href="https://prometheus-operator.dev/docs/getting-started/introduction/"
+  description="Get started with Prometheus-Operator."
+>}}
 
-### Tutorial
+<!-- API -->
+{{<link-card
+  title="API Reference"
+  href="https://prometheus-operator.dev/docs/api-reference/api/"
+  description="Reference for different fields of Custom Resources in Prometheus-Operator."
+>}}
 
-{{< alert icon="👉" text="The Tutorial is intended for novice to intermediate users." />}}
+<!-- Developer Guide -->
+{{<link-card
+  title="Developer Guide"
+  href="https://prometheus-operator.dev/docs/developer/getting-started/"
+  description="Learn how to configure monitoring for your applications."
+>}}
 
-We still need to write you a proper tutorial...
-Feel free to [comment on the opened issue](https://github.com/prometheus-operator/website/issues/3) if you want to help!
+<!-- Platform Guide -->
+{{<link-card
+  title="Platform Guide"
+  href="https://prometheus-operator.dev/docs/platform/webhook/"
+  description="Set up, configure and manage instances of Prometheus and related resources."
+>}}
 
-### Quick Start
-
-{{< alert icon="👉" text="The Quick Start is intended for intermediate to advanced users." />}}
-
-One page summary of how to start with the Prometheus Operator and kube-prometheus. [Quick Start →]({{< ref "quick-start" >}})
-
-## Go further
-
-Recipes, Reference Guides, Extensions, and Showcase.
-
-## Contributing
-
-Find out how to contribute to the Prometheus Operator and kube-prometheus. [Contributing →]({{< ref "contributing" >}})
-
-## Support
-
-We have [GitHub Discussions](https://github.com/prometheus-operator/kube-prometheus/discussions) for kube-prometheus.
-We recommend asking questions there, as this is searchable compared to Slack.
-
-We're happy to talk to you on the [Kubernetes Slack](http://slack.k8s.io/) in #prometheus-operator!
+<!-- Community -->
+{{<link-card
+  title="Community"
+  href="https://prometheus-operator.dev/docs/community/contributing/"
+  description="Join and interact with Prometheus-Operator community."
+>}}

--- a/layouts/shortcodes/card-grid.html
+++ b/layouts/shortcodes/card-grid.html
@@ -1,0 +1,3 @@
+<div class="card-nav d-flex flex-column flex-sm-row" gap="20">
+    {{ .Inner }}
+  </div>

--- a/layouts/shortcodes/card-grid.html
+++ b/layouts/shortcodes/card-grid.html
@@ -1,3 +1,3 @@
 <div class="card-nav d-flex flex-column flex-sm-row" gap="20">
     {{ .Inner }}
-  </div>
+</div>

--- a/layouts/shortcodes/link-card.html
+++ b/layouts/shortcodes/link-card.html
@@ -1,0 +1,36 @@
+{{- $opts := dict
+    "page" .
+    "href" .Params.href
+    "title" .Params.title
+    "description" .Params.description
+    "target" .Params.target
+    "class" .Params.class
+    "rel" .Params.rel
+  }}
+  
+  {{- with .Parent }}
+    {{- partial "inline/link-card.html" $opts }}
+  {{- else }}
+    <div class="card-nav d-flex flex-column flex-sm-row" style="padding: 5px;">
+      {{- partial "inline/link-card.html" $opts }}
+    </div>
+  {{- end }}
+  
+  {{- define "partials/inline/link-card.html" }}
+    <div class="card text-end w-100{{ with .class}} {{ . }}{{ end }}">
+      <div class="card-body d-flex">
+        <div class="d-flex flex-column me-auto text-start">
+          <h5 class="card-title my-0"><a href="{{ .href }}"{{ with .target}} target="{{ . }}"{{ end }} class="stretched-link text-reset text-decoration-none"{{ with .rel}} rel="{{ . }}"{{ end }}>{{ .title }}</a></h5>
+          {{ with .description }}<p class="card-text mt-1">{{ . }}</p>{{ end }}
+        </div>
+        <div class="d-flex flex-column justify-content-center">
+          <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-arrow-right" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+            <path d="M5 12l14 0"></path>
+            <path d="M13 18l6 -6"></path>
+            <path d="M13 6l6 6"></path>
+          </svg>
+        </div>
+      </div>
+    </div>
+  {{- end -}}


### PR DESCRIPTION
According to the issue #82 , I have added links to different guides on the Introduction page and removed the unwanted content (Get-Started section) from the Introduction page .

This PR solves a part of #82 .

> Small boxes that redirect people to what they care about, similar to https://nextjs.org/docs#join-our-community