### PR TITLE
Reorder Platform and Developer Guides

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -16,16 +16,16 @@
   url = "/docs/api-reference/"
 
 [[docs]]
-  name = "Developer Guide"
-  weight = 30
-  identifier = "/docs/developer/"
-  url = "/docs/developer/"
-
-[[docs]]
   name = "Platform Guide"
-  weight = 40
+  weight = 30
   identifier = "platform"
   url = "/docs/platform/"
+
+[[docs]]
+  name = "Developer Guide"
+  weight = 40
+  identifier = "/docs/developer/"
+  url = "/docs/developer/"
 
 [[docs]]
   name = "Community"

--- a/content/docs/developer/_index.md
+++ b/content/docs/developer/_index.md
@@ -4,5 +4,5 @@ description: "Prometheus operator and kube-prometheus user guides"
 lead: ""
 draft: false
 images: []
-weight: 200
+weight: 250
 ---

--- a/content/docs/getting-started/introduction.md
+++ b/content/docs/getting-started/introduction.md
@@ -68,18 +68,18 @@ Take a look at these guides to get into action with Prometheus Operator.
   description="Reference for different fields of Custom Resources in Prometheus-Operator."
 >}}
 
-<!-- Developer Guide -->
-{{<link-card
-  title="Developer Guide"
-  href="https://prometheus-operator.dev/docs/developer/getting-started/"
-  description="Learn how to configure scraping, alerting, and recording rules for your applications."
->}}
-
 <!-- Platform Guide -->
 {{<link-card
   title="Platform Guide"
   href="https://prometheus-operator.dev/docs/platform/webhook/"
   description="Set up, configure and manage instances of Prometheus-Operator, Prometheus, Alertmanager and ThanosRuler resources."
+>}}
+
+<!-- Developer Guide -->
+{{<link-card
+  title="Developer Guide"
+  href="https://prometheus-operator.dev/docs/developer/getting-started/"
+  description="Learn how to configure scraping, alerting, and recording rules for your applications."
 >}}
 
 <!-- Community -->

--- a/content/docs/platform/_index.md
+++ b/content/docs/platform/_index.md
@@ -6,5 +6,5 @@ date: 2020-10-06T08:49:15+00:00
 lastmod: 2020-10-06T08:49:15+00:00
 draft: false
 images: []
-weight: 250
+weight: 200
 ---

--- a/synchronize.sh
+++ b/synchronize.sh
@@ -6,7 +6,8 @@ rm -rf repos/
 mkdir repos/
 
 if [[ -z "$USE_LOCAL_REPOSITORIES" ]]; then
-  git clone https://github.com/prometheus-operator/prometheus-operator -b main --depth 1 repos/prometheus-operator
+  # git clone https://github.com/prometheus-operator/prometheus-operator -b main --depth 1 repos/prometheus-operator
+  git clone https://github.com/AshwinSriram11/prometheus-operator -b Reorder-Guides repos/prometheus-operator
   git clone https://github.com/prometheus-operator/kube-prometheus -b main --depth 1 repos/kube-prometheus
 else
   ln -s ../../prometheus-operator repos/prometheus-operator 
@@ -28,11 +29,6 @@ cp repos/prometheus-operator/Documentation/design.md content/docs/getting-starte
 # api section
 cp repos/prometheus-operator/Documentation/api.md content/docs/api-reference/api.md
 
-# developer guide
-cp repos/prometheus-operator/Documentation/user-guides/getting-started.md content/docs/developer/getting-started.md
-cp repos/prometheus-operator/Documentation/user-guides/alerting.md content/docs/developer/alerting.md
-cp repos/prometheus-operator/Documentation/user-guides/scrapeconfig.md content/docs/developer/scrapeconfig.md
-
 # platform guide
 cp repos/prometheus-operator/Documentation/user-guides/webhook.md content/docs/platform/webhook.md
 cp repos/prometheus-operator/Documentation/user-guides/prometheus-agent.md content/docs/platform/prometheus-agent.md
@@ -44,6 +40,11 @@ cp repos/prometheus-operator/Documentation/thanos.md content/docs/platform/thano
 cp repos/prometheus-operator/Documentation/troubleshooting.md content/docs/platform/troubleshooting.md
 cp repos/prometheus-operator/Documentation/user-guides/storage.md content/docs/platform/storage.md
 cp repos/prometheus-operator/Documentation/user-guides/strategic-merge-patch.md content/docs/platform/strategic-merge-patch.md
+
+# developer guide
+cp repos/prometheus-operator/Documentation/user-guides/getting-started.md content/docs/developer/getting-started.md
+cp repos/prometheus-operator/Documentation/user-guides/alerting.md content/docs/developer/alerting.md
+cp repos/prometheus-operator/Documentation/user-guides/scrapeconfig.md content/docs/developer/scrapeconfig.md
 
 # community section
 cp repos/prometheus-operator/CONTRIBUTING.md content/docs/community/contributing.md


### PR DESCRIPTION
This PR switches the order of Platform and Developer Guides. A [PR](https://github.com/prometheus-operator/prometheus-operator/pull/6852) to change the order of each page is in the main repository.

 