### PR TITLE
Fix: Source Repository for Website

### DIFF
--- a/synchronize.sh
+++ b/synchronize.sh
@@ -6,8 +6,7 @@ rm -rf repos/
 mkdir repos/
 
 if [[ -z "$USE_LOCAL_REPOSITORIES" ]]; then
-  # git clone https://github.com/prometheus-operator/prometheus-operator -b main --depth 1 repos/prometheus-operator
-  git clone https://github.com/AshwinSriram11/prometheus-operator -b Reorder-Guides repos/prometheus-operator
+  git clone https://github.com/prometheus-operator/prometheus-operator -b main --depth 1 repos/prometheus-operator
   git clone https://github.com/prometheus-operator/kube-prometheus -b main --depth 1 repos/kube-prometheus
 else
   ln -s ../../prometheus-operator repos/prometheus-operator 


### PR DESCRIPTION
In #100, I changed the source for the Prometheus operator repository to my fork for viewing the preview for the website. The PR was merged before merging the main [PR](https://github.com/prometheus-operator/prometheus-operator/pull/6852) in the Prometheus operator repository. Currently, the website fetches docs from my fork of the main repository.

This PR changes it back to the main repository.