### PR TITLE
Add Website Preview for New Documentation Page and Fixed Links

### DIFF
--- a/synchronize.sh
+++ b/synchronize.sh
@@ -6,7 +6,7 @@ rm -rf repos/
 mkdir repos/
 
 if [[ -z "$USE_LOCAL_REPOSITORIES" ]]; then
-  git clone https://github.com/prometheus-operator/prometheus-operator -b main --depth 1 repos/prometheus-operator
+  git clone https://github.com/Dharma-09/prometheus-operator -b main --depth 1 repos/prometheus-operator
   git clone https://github.com/prometheus-operator/kube-prometheus -b main --depth 1 repos/kube-prometheus
 else
   ln -s ../../prometheus-operator repos/prometheus-operator 

--- a/synchronize.sh
+++ b/synchronize.sh
@@ -6,7 +6,7 @@ rm -rf repos/
 mkdir repos/
 
 if [[ -z "$USE_LOCAL_REPOSITORIES" ]]; then
-  git clone https://github.com/Dharma-09/prometheus-operator -b main --depth 1 repos/prometheus-operator
+  git clone https://github.com/prometheus-operator/prometheus-operator -b main --depth 1 repos/prometheus-operator
   git clone https://github.com/prometheus-operator/kube-prometheus -b main --depth 1 repos/kube-prometheus
 else
   ln -s ../../prometheus-operator repos/prometheus-operator 

--- a/synchronize.sh
+++ b/synchronize.sh
@@ -7,7 +7,6 @@ mkdir repos/
 
 if [[ -z "$USE_LOCAL_REPOSITORIES" ]]; then
   git clone https://github.com/Dharma-09/prometheus-operator -b main --depth 1 repos/prometheus-operator
-  # git clone https://github.com/prometheus-operator/prometheus-operator -b main --depth 1 repos/prometheus-operator
   git clone https://github.com/prometheus-operator/kube-prometheus -b main --depth 1 repos/kube-prometheus
 else
   ln -s ../../prometheus-operator repos/prometheus-operator 

--- a/synchronize.sh
+++ b/synchronize.sh
@@ -7,6 +7,7 @@ mkdir repos/
 
 if [[ -z "$USE_LOCAL_REPOSITORIES" ]]; then
   git clone https://github.com/Dharma-09/prometheus-operator -b main --depth 1 repos/prometheus-operator
+  # git clone https://github.com/prometheus-operator/prometheus-operator -b main --depth 1 repos/prometheus-operator
   git clone https://github.com/prometheus-operator/kube-prometheus -b main --depth 1 repos/kube-prometheus
 else
   ln -s ../../prometheus-operator repos/prometheus-operator 

--- a/synchronize.sh
+++ b/synchronize.sh
@@ -32,6 +32,7 @@ cp repos/prometheus-operator/Documentation/api.md content/docs/api-reference/api
 
 # platform guide
 cp repos/prometheus-operator/Documentation/platform-guide.md content/docs/platform/platform-guide.md
+cp repos/prometheus-operator/Documentation/user-guides/exposing-prometheus-and-alertmanager.md content/docs/platform/exposing-prometheus-and-alertmanager.md
 cp repos/prometheus-operator/Documentation/user-guides/webhook.md content/docs/platform/webhook.md
 cp repos/prometheus-operator/Documentation/user-guides/prometheus-agent.md content/docs/platform/prometheus-agent.md
 cp repos/prometheus-operator/Documentation/operator.md content/docs/platform/operator.md


### PR DESCRIPTION
**This pull request updates the synchronization.sh file in the website repository to include the new Prometheus & Alertmanager Exposure Guide.**

**Here is the first preview, confirming that the new documentation page is working as expected.**
1. ![Screenshot from 2024-12-14 12-57-36](https://github.com/user-attachments/assets/0a3260bd-790a-42e9-bef2-4fd0c7215c9f)

The remaining screenshots state that the broken links have been fixed and no longer result in 404 errors.

![Screenshot from 2024-12-14 13-09-49](https://github.com/user-attachments/assets/645e459f-5582-49e8-ae72-7d0abbcc5b1e)
![Screenshot from 2024-12-14 13-09-43](https://github.com/user-attachments/assets/051e47e6-ca8a-4b1d-984b-e7c8bc2a8577)

