### PR TITLE
Fix for pagination in config.toml

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -5,7 +5,7 @@ enableEmoji = true
 enableGitInfo = true
 enableRobotsTXT = true
 languageCode = "en-US"
-paginate = 7
+pagination.pagerSize = 7
 rssLimit = 10
 
 ## add redirects/headers


### PR DESCRIPTION
On running `hugo serve` locally, the following error was displayed:

```
ERROR deprecated: site config key paginate was deprecated in Hugo v0.128.0 and subsequently removed. Use pagination.pagerSize instead.
```

This PR solves the following problem.

Related issue: #128 