### PR TITLE
Disable header animation occupying an entire CPU core

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -64,9 +64,11 @@ $link-hover-color: $secondary;
   background: linear-gradient(90deg, var(--kubernetes), var(--prometheus), var(--kubernetes));
   background-size: 200% 200%;
 
+  /* FIXME: This animation causes 100% CPU load?
   -webkit-animation: headerBarGradient 15s ease infinite;
   -moz-animation: headerBarGradient 15s ease infinite;
   animation: headerBarGradient 15s ease infinite;
+  */
 }
 
 @-webkit-keyframes headerBarGradient {


### PR DESCRIPTION
I encountered what other people already described in #67.

It maxes out an entire CPU core, which is really annoying since even when you have many cores and your system is otherwise stable, it tends to send laptops into jetfighter-mode. (Fans) :airplane: 

I played around a bit and narrowed it down to CSS, specifically animations. 

I've built the site locally, removed the `integrity` attributes from the stylesheet link element and then removed all instances of `animation` from `main.1b4487d9f55444088d019c101002f026ffc1b6b4070c63ecabb1c3ec5a7d07d687492b0adf14d76ee0c0b77619ce2bbfb5b39983b5755277365b0aa8417e2e64.css`

Then I added the animations back in one by one, which leds me to conclude 
that the culprit is `headerBarGradient` animation on `.header-bar`, implemented [here](https://github.com/prometheus-operator/website/blob/a247e74ee8293dae3107f2b7dd460becb10307b3/assets/scss/app.scss#L67).

After commenting out the animation and rebuilding the local site, it no longer occupies my CPU. Since this is just eye-candy, it might be a good Idea to just disable this, deploy it and wait until someone has time to figure out why this animation is so taxing on CPU. I personally have very limited experience with CSS animations.